### PR TITLE
Remove deprecated mobileReady tag

### DIFF
--- a/force-app/main/default/tabs/Google_BigQuery.tab-meta.xml
+++ b/force-app/main/default/tabs/Google_BigQuery.tab-meta.xml
@@ -2,6 +2,5 @@
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <auraComponent>GoogleBigQuery</auraComponent>
     <label>Google BigQuery</label>
-    <mobileReady>false</mobileReady>
     <motif>Custom68: Globe</motif>
 </CustomTab>


### PR DESCRIPTION
As of today `mobileReady` is now deprecated. The tab cannot be saved with this.